### PR TITLE
I changed this versions to avoid one error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,9 @@ buildscript {
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
     }
 }
+
 plugins {
-    id 'com.android.application' version '8.0.0-alpha09' apply false
-    id 'com.android.library' version '8.0.0-alpha09' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }


### PR DESCRIPTION
After downloading this project I was getting one error during building so I updated my android studio and changed this versions.

ERROR MESSAGE - 
The project is using an incompatible version (AGP 8.0.0-alpha09) of the Android Gradle plugin. Latest supported version is AGP 7.3.1